### PR TITLE
Feat/style selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ npm run test
 ```
 npm run ci
 ```
-This runs lint, unit tests, and the production build. Use this before pushing to `main`, since Netlify deploys from that branch.
+This runs lint, TypeScript type-checking for app and test files, unit tests, and the production build. Use this before pushing to `main`, since Netlify deploys from that branch.
 
 ### Preview the production build
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,8 @@ Suggested acceptance checks:
 
 ## Phase 2: Rewrite Automatic Style Selection
 
+Status: implemented on `feat/style-selection`
+
 Priority: high
 
 Current problem:
@@ -62,6 +64,13 @@ Suggested acceptance checks:
 - A sample matrix of common browsers/timezones/languages produces broad distribution across most registered styles.
 - Style selection is stable for the same traits.
 - Manual style override still works.
+
+Implemented notes:
+
+- `chooseStyleFromFingerprint()` now uses a versioned weighted score across every registered style instead of returning on the first matching rule.
+- Scoring includes full fingerprint, IP, geolocation, timezone, language, browser family, screen bucket, device pixel ratio, and color-scheme preference.
+- Debug output reports the winning style, score, and runner-up.
+- Unit tests cover registered-style validity, deterministic output, and broad distribution across common trait combinations.
 
 ## Phase 3: Add Audio Sonification
 
@@ -140,9 +149,7 @@ Ideas:
 
 ## Suggested Next Steps
 
-1. Fix the small correctness bugs first: IP application, wave transform, lint warning, invalid `"stata"` style ID.
-2. Stabilize animation before adding audio; otherwise audio work will be harder to judge during long-running demos.
-3. Replace style selection with a scored deterministic selector and test it against sample trait sets.
-4. Add the smallest useful Web Audio API implementation: start/stop, volume, and deterministic sound mapping from `GenerationState`.
-5. Do a timed rehearsal on the actual demo machine or a similar laptop, with browser devtools memory/performance open.
-
+1. Manually sample the new automatic style selection across a few devices/browsers.
+2. Open a Phase 2 PR after `npm run ci` passes.
+3. Start Phase 3 audio with a small Web Audio API implementation: start/stop, volume, and deterministic sound mapping from `GenerationState`.
+4. Do a timed rehearsal on the actual demo machine or a similar laptop, with browser devtools memory/performance open.

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "ci": "npm run lint && npm run test:run && npm run build",
+    "ci": "npm run lint && npm run typecheck && npm run test:run && npm run build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "typecheck": "tsc -p tsconfig.test.json --noEmit"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { useIpInfo } from "./hooks/useIpInfo";
 import { useIsMobile } from "./hooks/useIsMobile";
 import "./App.css";
 
+const STARTING_ANIMATION_STATE = true;
 const NORMAL_ANIMATION_FPS = 12;
 const REDUCED_MOTION_ANIMATION_FPS = 4;
 const NORMAL_COMPLEXITY_SPEED = 24;
@@ -31,7 +32,7 @@ const REDUCED_MOTION_COMPLEXITY_SPEED = 8;
 
 const App: React.FC = () => {
   const [baseTraits] = useState<UserTraits>(() => getBaseTraits());
-  const [isAnimating, setIsAnimating] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(STARTING_ANIMATION_STATE);
   const [hudHidden, setHudHidden] = useState(false);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const complexityDirectionRef = useRef<1 | -1>(1);

--- a/src/logic/styleRules.ts
+++ b/src/logic/styleRules.ts
@@ -3,41 +3,13 @@
 import { STYLES } from "../components/art/styleRegistry";
 import type { StyleId, UserTraits } from "./types";
 
-const IP_BUCKET_STYLES: StyleId[] = [
-  "orbits",
-  "strata",
-  "bubbles",
-  "waves",
-  "fern",
-  "crystal",
-  "tree"
-];
+const STYLE_SELECTION_VERSION = "style-v2";
 
-const BROWSER_STYLES: Record<string, StyleId> = {
-  chrome: "isogrid",
-  edge: "koch",
-  firefox: "flowfield",
-  safari: "nebula",
-  opera: "aurora"
-};
-
-const CONTINENT_STYLES: Record<string, StyleId> = {
-  "NA": "orbits",
-  "SA": "strata",
-  "EU": "lattice",
-  "AF": "nebula",
-  "AS": "aurora",
-  "OC": "bubbles",
-};
-
-const LANGUAGE_STYLES: Record<string, StyleId> = {
-  "en": "orbits",
-  "es": "strata",
-  "fr": "constellation",
-  "de": "lattice",
-  "ja": "waves",
-  "ko": "crystal",
-};
+interface StyleSignal {
+  label: string;
+  value: string;
+  weight: number;
+}
 
 function simpleHash(str: string): number {
   let h = 0;
@@ -56,6 +28,83 @@ function getBrowserFamily(ua: string | null | undefined): string | null {
   if (s.includes("safari/")) return "safari";
   if (s.includes("opr/") || s.includes("opera")) return "opera";
   return null;
+}
+
+function getScreenBucket(traits: UserTraits): string {
+  const shortSide = Math.min(traits.screenWidth, traits.screenHeight);
+  const longSide = Math.max(traits.screenWidth, traits.screenHeight);
+  const orientation = traits.screenWidth >= traits.screenHeight
+    ? "landscape"
+    : "portrait";
+
+  if (longSide <= 0) return "unknown";
+  if (shortSide < 600) return `small-${orientation}`;
+  if (shortSide < 900) return `medium-${orientation}`;
+  return `large-${orientation}`;
+}
+
+function getLanguageFamily(language: string): string {
+  return language.split("-")[0]?.toLowerCase() || "unknown";
+}
+
+function hashToUnitInterval(input: string): number {
+  return simpleHash(input) / 0xffffffff;
+}
+
+function getStyleSignals(traits: UserTraits): StyleSignal[] {
+  const family = getBrowserFamily(traits.userAgent) ?? "unknown";
+  const continent = traits.ipInfo?.continentCode ?? "unknown";
+  const country = traits.ipInfo?.country ?? "unknown";
+  const region = traits.ipInfo?.region ?? "unknown";
+  const city = traits.ipInfo?.city ?? "unknown";
+  const ip = traits.ipInfo?.ip ?? "none";
+  const screen = getScreenBucket(traits);
+  const language = getLanguageFamily(traits.language);
+  const colorScheme = traits.darkMode ? "dark" : "light";
+  const dprBucket = traits.devicePixelRatio >= 2 ? "high-dpr" : "standard-dpr";
+
+  return [
+    {
+      label: "fingerprint",
+      value: JSON.stringify(traits),
+      weight: 6,
+    },
+    {
+      label: "ip",
+      value: ip,
+      weight: traits.ipInfo?.ip ? 2.5 : 0.25,
+    },
+    {
+      label: "geo",
+      value: `${continent}/${country}/${region}/${city}`,
+      weight: traits.ipInfo ? 1.5 : 0.35,
+    },
+    {
+      label: "timezone",
+      value: traits.timeZone || "unknown",
+      weight: 1.25,
+    },
+    {
+      label: "language",
+      value: language,
+      weight: 1,
+    },
+    {
+      label: "browser",
+      value: family,
+      weight: 1,
+    },
+    {
+      label: "screen",
+      value: `${screen}/${dprBucket}`,
+      weight: 0.9,
+    },
+    {
+      label: "color",
+      value: colorScheme,
+      weight: 0.5,
+    },
+  ];
 }
 
 export interface StyleDecision {
@@ -107,71 +156,42 @@ export function chooseStyle(
 }
 
 export function chooseStyleFromFingerprint(traits: UserTraits): StyleDecision {
-  const reasons: string[] = [];
-
-  // 1) IP bucket
-  if (traits.ipInfo?.ip) {
-    const hash = simpleHash(traits.ipInfo.ip);
-    const bucketIdx = hash % IP_BUCKET_STYLES.length;
-    const style = IP_BUCKET_STYLES[bucketIdx];
-
-    reasons.push(
-      `IP bucket: hash(${traits.ipInfo.ip}) >> bucket ${bucketIdx} >> ${style}`
-    );
-
-    return {
-      id: style,
-      reason: reasons.join(" | "),
-    };
-  }
-
-  // 2) Browser family
-  const family = getBrowserFamily(traits.userAgent);
-  if (family && BROWSER_STYLES[family]) {
-    const style = BROWSER_STYLES[family];
-    reasons.push(`Browser: ${family} >> ${style}`);
-
-    return {
-      id: style,
-      reason: reasons.join(" | "),
-    };
-  }
-
-  // 3) Continent (fallback)
-  if (traits.ipInfo?.continentCode && CONTINENT_STYLES[traits.ipInfo.continentCode]) {
-    const style = CONTINENT_STYLES[traits.ipInfo.continentCode];
-    reasons.push(`Continent: ${traits.ipInfo.continentCode} >> ${style}`);
-
-    return {
-      id: style,
-      reason: reasons.join(" | "),
-    };
-  }
-
-  // 4) Language
-  if (traits.language) {
-    const lang = traits.language.split("-")[0].toLocaleLowerCase();
-    if (LANGUAGE_STYLES[lang]) {
-      const style = LANGUAGE_STYLES[lang];
-      reasons.push(`Language: ${lang} >> ${style}`);
-      return {
-        id: style,
-        reason: reasons.join(" | "),
-      };
-    }
-  }
-
-  // Ultimate fallback: hash entire fingerprint
-  const fingerprintString = JSON.stringify(traits);
-  const hash = simpleHash(fingerprintString);
   const allStyleIds = Object.keys(STYLES) as StyleId[];
-  const idx = hash % allStyleIds.length;
-  const style = allStyleIds[idx];
+  const signals = getStyleSignals(traits);
+  const ranked = allStyleIds
+    .map((styleId) => {
+      const score = signals.reduce((sum, signal) => {
+        const hashInput = [
+          STYLE_SELECTION_VERSION,
+          styleId,
+          signal.label,
+          signal.value,
+        ].join("|");
 
-  reasons.push(`Fallback: hash(fingerprint) >> ${style}`);
+        return sum + hashToUnitInterval(hashInput) * signal.weight;
+      }, 0);
+
+      return { styleId, score };
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return a.styleId.localeCompare(b.styleId);
+    });
+
+  const winner = ranked[0];
+  const runnerUp = ranked[1];
+  const signalSummary = signals
+    .filter((signal) => signal.weight >= 1)
+    .map((signal) => signal.label)
+    .join("+");
 
   return {
-    id: style,
-    reason: reasons.join(" | "),
+    id: winner.styleId,
+    reason:
+      `weighted fingerprint score (${signalSummary}) >> ` +
+      `${winner.styleId} ${winner.score.toFixed(3)}` +
+      (runnerUp
+        ? `, runner-up ${runnerUp.styleId} ${runnerUp.score.toFixed(3)}`
+        : ""),
   };
 }

--- a/tests/logic/styleRules.test.ts
+++ b/tests/logic/styleRules.test.ts
@@ -25,7 +25,7 @@ describe("chooseStyleFromFingerprint", () => {
         ipInfo: { ip: "198.51.100.10", continentCode: "NA" },
       }),
       makeTraits({
-        ipInfo: { continentCode: "SA" },
+        ipInfo: { ip: "", continentCode: "SA" },
       }),
       makeTraits({
         userAgent:
@@ -53,13 +53,77 @@ describe("chooseStyleFromFingerprint", () => {
     }
   });
 
-  it("keeps the South America fallback mapped to the registered strata style", () => {
-    const decision = chooseStyleFromFingerprint(
-      makeTraits({
-        ipInfo: { continentCode: "SA" },
-      })
-    );
+  it("is stable for the same trait set", () => {
+    const traits = makeTraits({
+      timeZone: "America/Chicago",
+      language: "es-US",
+      userAgent:
+        "Mozilla/5.0 AppleWebKit/537.36 Chrome/120.0 Safari/537.36",
+      screenWidth: 1920,
+      screenHeight: 1080,
+      devicePixelRatio: 1,
+      darkMode: true,
+      ipInfo: {
+        ip: "198.51.100.44",
+        city: "Example City",
+        region: "Example Region",
+        country: "Example Country",
+        continentCode: "SA",
+      },
+    });
 
-    expect(decision.id).toBe("strata");
+    expect(chooseStyleFromFingerprint(traits)).toEqual(
+      chooseStyleFromFingerprint(traits)
+    );
+  });
+
+  it("spreads common visitor trait combinations across many styles", () => {
+    const browsers = [
+      "Mozilla/5.0 AppleWebKit/537.36 Chrome/120.0 Safari/537.36",
+      "Mozilla/5.0 Edg/120.0",
+      "Mozilla/5.0 Firefox/121.0",
+      "Mozilla/5.0 Version/17.0 Safari/605.1.15",
+      "Mozilla/5.0 OPR/106.0",
+    ];
+    const timeZones = [
+      "America/New_York",
+      "America/Los_Angeles",
+      "Europe/London",
+      "Europe/Berlin",
+      "Asia/Tokyo",
+      "Australia/Sydney",
+    ];
+    const languages = ["en-US", "es-MX", "fr-CA", "de-DE"];
+    const screens = [
+      { screenWidth: 390, screenHeight: 844, devicePixelRatio: 3 },
+      { screenWidth: 1366, screenHeight: 768, devicePixelRatio: 1 },
+      { screenWidth: 1920, screenHeight: 1080, devicePixelRatio: 2 },
+    ];
+
+    const counts = new Map<string, number>();
+
+    for (const userAgent of browsers) {
+      for (const timeZone of timeZones) {
+        for (const language of languages) {
+          for (const screen of screens) {
+            const decision = chooseStyleFromFingerprint(
+              makeTraits({
+                userAgent,
+                timeZone,
+                language,
+                ...screen,
+              })
+            );
+            counts.set(decision.id, (counts.get(decision.id) ?? 0) + 1);
+          }
+        }
+      }
+    }
+
+    const mostCommonCount = Math.max(...counts.values());
+    const totalCount = browsers.length * timeZones.length * languages.length * screens.length;
+
+    expect(counts.size).toBeGreaterThanOrEqual(12);
+    expect(mostCommonCount / totalCount).toBeLessThan(0.2);
   });
 });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- Replace short-circuit automatic style selection with a deterministic weighted scoring algorithm
- Use all registered styles as eligible auto-start candidates
- Add style-selection tests for validity, stability, and broad distribution
- Add test-file TypeScript checking to local CI

## Details
The new selector scores every registered style using multiple visitor traits:
- full fingerprint
- IP/geolocation when available
- timezone
- language
- browser family
- screen/device pixel ratio bucket
- color-scheme preference

The debug reason now reports the winning style, score, and runner-up so auto-mode remains explainable.

## Verification
- `npm run ci`
- Manual spot check recommended: load auto mode in browser and confirm debug output shows `weighted fingerprint score (...)`