### PR TITLE
Feat/sonification

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ A simple animation toggle smoothly sweeps complexity from 0 to 100 to 0, creatin
 
 ### 🔊 Sonification
 
-The Sound control starts a Web Audio interpretation of the current artwork. Style, seed, palette, and complexity influence the tempo, notes, waveform, brightness, and stereo movement.
+The Sound control starts a Web Audio interpretation of the current artwork. Style, seed, palette, and complexity influence the tempo, notes, waveform, brightness, stereo movement, echo, rhythm, and chord/drone accents.
+
+Audio profiles are designed to loosely match the visual language: orbits pulse, strata drones, constellations sparkle, grids tick, branches split into short echoes, and flow-style visuals drift.
 
 Audio starts only after a button press, matching browser autoplay rules.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Every visitor gets a unique artwork generated from:
 - browser traits
 - IP/geolocation info
 - randomness derived from a deterministic seed
+- deterministic sound derived from the same seed and style inputs
 - optional manual controls (sliders, style selectors, palette shuffling)
 
 …and nothing leaves your device. No server, no backend, no AI APIs — just CSS, JavaScript, and vibes.
@@ -47,6 +48,12 @@ Flip a toggle to override auto mode:
 
 A simple animation toggle smoothly sweeps complexity from 0 to 100 to 0, creating a screensaver effect across all styles.
 
+### 🔊 Sonification
+
+The Sound control starts a Web Audio interpretation of the current artwork. Style, seed, palette, and complexity influence the tempo, notes, waveform, brightness, and stereo movement.
+
+Audio starts only after a button press, matching browser autoplay rules.
+
 ### 🪩 Debug Panel
 
 Shows:
@@ -81,7 +88,9 @@ src/
       DebugPanel.tsx
   hooks/
     useIpInfo.ts
+    useSonification.ts
   logic/
+    audioMapping.ts
     fingerprint.ts
     generation.ts
     rng.ts
@@ -97,6 +106,7 @@ src/
 4. Build a GenerationState object
 5. ArtContainer selects the correct style component
 6. Style component renders with CSS + transforms
+7. Optional sonification maps GenerationState to Web Audio notes
 
 ## 🧪 Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,6 +74,8 @@ Implemented notes:
 
 ## Phase 3: Add Audio Sonification
 
+Status: initial implementation on `feat/sonification`
+
 Priority: high
 
 Recommended architecture:
@@ -113,6 +115,13 @@ Suggested acceptance checks:
 - Audio does not clip or become painfully loud.
 - Visual animation can be off while audio remains meaningful.
 
+Implemented notes:
+
+- `buildAudioState()` maps `GenerationState` to deterministic tempo, notes, waveform, filter brightness, gain, and stereo pan.
+- `useSonification()` owns the Web Audio engine and starts only from user interaction.
+- MiniHud exposes a visible Sound button; ControlPanel exposes start/stop, volume, current audio summary, and errors.
+- Unit tests cover deterministic mapping, complexity-to-density behavior, and conservative audio parameter ranges.
+
 ## Phase 4: Accessibility And Presentation Polish
 
 Priority: medium
@@ -149,7 +158,7 @@ Ideas:
 
 ## Suggested Next Steps
 
-1. Manually sample the new automatic style selection across a few devices/browsers.
-2. Open a Phase 2 PR after `npm run ci` passes.
-3. Start Phase 3 audio with a small Web Audio API implementation: start/stop, volume, and deterministic sound mapping from `GenerationState`.
+1. Manually test sound start/stop and volume in Chrome, Safari, Firefox, and at least one mobile browser.
+2. Tune each style's sound personality for the demo: orbits, strata, constellation, bubbles, waves, tree, aurora, nebula, and flowfield should be clearly distinguishable.
+3. Add a concise screen-reader summary that includes both visual style and sound state.
 4. Do a timed rehearsal on the actual demo machine or a similar laptop, with browser devtools memory/performance open.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,7 +74,7 @@ Implemented notes:
 
 ## Phase 3: Add Audio Sonification
 
-Status: initial implementation on `feat/sonification`
+Status: Phase 3B sound-spruce pass implemented on `feat/sonification`
 
 Priority: high
 
@@ -121,6 +121,13 @@ Implemented notes:
 - `useSonification()` owns the Web Audio engine and starts only from user interaction.
 - MiniHud exposes a visible Sound button; ControlPanel exposes start/stop, volume, current audio summary, and errors.
 - Unit tests cover deterministic mapping, complexity-to-density behavior, and conservative audio parameter ranges.
+
+Phase 3B notes:
+
+- Added style-specific audio profiles so visual styles map to more distinct sound modes: pulse, drone, sparkle, pluck, wave, grid, bloom, branch, and flow.
+- Added profile-driven scales, waveforms, rhythms, envelopes, echo settings, filter resonance, root offsets, and chord/drone accents.
+- The Web Audio engine now supports rhythmic spacing, echo feedback, accent notes, branch/sparkle follow-up notes, and occasional chord/drone layers.
+- Unit tests now verify that representative visual styles produce distinct audio modes, waveforms, and summaries.
 
 ## Phase 4: Accessibility And Presentation Polish
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@vitejs/plugin-react": "^5.1.0",
+        "baseline-browser-mapping": "^2.10.31",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -2001,13 +2002,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.29.tgz",
-      "integrity": "sha512-sXdt2elaVnhpDNRDz+1BDx1JQoJRuNk7oVlAlbGiFkLikHCAQiccexF/9e91zVi6RCgqspl04aP+6Cnl9zRLrA==",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^5.1.0",
+    "baseline-browser-mapping": "^2.10.31",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import ArtContainer from "./components/ui/ArtContainer";
 import MiniHud from "./components/ui/MiniHud";
 import { useIpInfo } from "./hooks/useIpInfo";
 import { useIsMobile } from "./hooks/useIsMobile";
+import { useSonification } from "./hooks/useSonification";
 import "./App.css";
 
 const STARTING_ANIMATION_STATE = true;
@@ -57,6 +58,14 @@ const App: React.FC = () => {
     () => buildGenerationState(traits, options),
       [traits, options]
   );
+  const {
+    audioState,
+    isAudioEnabled,
+    audioVolume,
+    audioError,
+    toggleAudio,
+    setAudioVolume,
+  } = useSonification(generationState);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -182,6 +191,12 @@ const App: React.FC = () => {
         onShufflePalette={handleShufflePalette}
         isAnimating={isAnimating}
         onToggleAnimation={handleToggleAnimation}
+        isAudioEnabled={isAudioEnabled}
+        audioVolume={audioVolume}
+        audioSummary={audioState.summary}
+        audioError={audioError}
+        onToggleAudio={toggleAudio}
+        onAudioVolumeChange={setAudioVolume}
         isMobile={isMobile}
         hudHidden={hudHidden}
       />
@@ -198,9 +213,11 @@ const App: React.FC = () => {
         manualStyle={options.manualStyle ?? null}
         effectiveStyle={generationState.styleId}
         isAnimating={isAnimating}
+        isAudioEnabled={isAudioEnabled}
         onModeChange={handleModeChange}
         onStyleChange={handleStyleChange}
         onToggleAnimation={handleToggleAnimation}
+        onToggleAudio={toggleAudio}
       />
     </div>
   );

--- a/src/components/ui/ControlPanel.css
+++ b/src/components/ui/ControlPanel.css
@@ -111,6 +111,10 @@
   color: #6b7280;
 }
 
+.control-hint--error {
+  color: #fca5a5;
+}
+
 .control-range {
   flex: 1;
 }

--- a/src/components/ui/ControlPanel.tsx
+++ b/src/components/ui/ControlPanel.tsx
@@ -28,6 +28,12 @@ interface ControlPanelProps {
   onShufflePalette: () => void;
   isAnimating: boolean;
   onToggleAnimation: () => void;
+  isAudioEnabled: boolean;
+  audioVolume: number;
+  audioSummary: string;
+  audioError: string | null;
+  onToggleAudio: () => void | Promise<void>;
+  onAudioVolumeChange: (volume: number) => void;
   isMobile?: boolean;
   hudHidden?: boolean;
 }
@@ -44,6 +50,12 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
   onShufflePalette,
   isAnimating,
   onToggleAnimation,
+  isAudioEnabled,
+  audioVolume,
+  audioSummary,
+  audioError,
+  onToggleAudio,
+  onAudioVolumeChange,
   isMobile = false,
   hudHidden
 }) => {
@@ -77,6 +89,13 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
     const value = Number(event.target.value);
     if (!Number.isNaN(value)) {
       onComplexityChange(value);
+    }
+  };
+
+  const handleAudioVolumeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (!Number.isNaN(value)) {
+      onAudioVolumeChange(value / 100);
     }
   };
 
@@ -232,6 +251,43 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                   <span>Animate Complexity</span>
                 </label>
               </div>
+            </div>
+          </div>
+
+          <div className="control-section">
+            <div className="control-row">
+              <span className="control-label">Sound</span>
+              <div className="control-value control-seed-row">
+                <button
+                  type="button"
+                  className="control-button"
+                  aria-pressed={isAudioEnabled}
+                  onClick={() => {
+                    void onToggleAudio();
+                  }}
+                >
+                  {isAudioEnabled ? "Stop sound" : "Start sound"}
+                </button>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={1}
+                  className="control-range"
+                  value={Math.round(audioVolume * 100)}
+                  onChange={handleAudioVolumeChange}
+                  aria-label="Sound volume"
+                />
+                <span className="control-range-value">
+                  {Math.round(audioVolume * 100)}
+                </span>
+              </div>
+              <div className="control-hint">{audioSummary}</div>
+              {audioError && (
+                <div className="control-hint control-hint--error">
+                  {audioError}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -391,6 +447,43 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                       <span>Animate complexity</span>
                     </label>
                   </div>
+                </div>
+              </div>
+
+              <div className="control-section">
+                <div className="control-row">
+                  <span className="control-label">Sound</span>
+                  <div className="control-value control-seed-row">
+                    <button
+                      type="button"
+                      className="control-button"
+                      aria-pressed={isAudioEnabled}
+                      onClick={() => {
+                        void onToggleAudio();
+                      }}
+                    >
+                      {isAudioEnabled ? "Stop sound" : "Start sound"}
+                    </button>
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={1}
+                      className="control-range"
+                      value={Math.round(audioVolume * 100)}
+                      onChange={handleAudioVolumeChange}
+                      aria-label="Sound volume"
+                    />
+                    <span className="control-range-value">
+                      {Math.round(audioVolume * 100)}
+                    </span>
+                  </div>
+                  <div className="control-hint">{audioSummary}</div>
+                  {audioError && (
+                    <div className="control-hint control-hint--error">
+                      {audioError}
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/src/components/ui/MiniHud.css
+++ b/src/components/ui/MiniHud.css
@@ -36,6 +36,15 @@
   font-size: 1.1rem;
 }
 
+.mini-hud__button--sound {
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.98);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 .mini-hud__label {
   min-height: 44px;
   border: none;
@@ -75,6 +84,12 @@
   box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.35);
 }
 
+.mini-hud--audio-on .mini-hud__button--sound {
+  border-color: rgba(56, 189, 248, 0.9);
+  color: #f9fafb;
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.45);
+}
+
 /* Tiny tweak so HUD doesn't fight on very small screens */
 @media (max-width: 480px) {
   .mini-hud {
@@ -84,7 +99,7 @@
 
   .mini-hud__label {
     padding-inline: 0.45rem;
-    max-width: 60vw;
+    max-width: 42vw;
   }
 
   .mini-hud__text {

--- a/src/components/ui/MiniHud.tsx
+++ b/src/components/ui/MiniHud.tsx
@@ -8,9 +8,11 @@ interface MiniHudProps {
   manualStyle: StyleId | null;
   effectiveStyle: StyleId;
   isAnimating: boolean;
+  isAudioEnabled: boolean;
   onModeChange: (mode: Mode) => void;
   onStyleChange: (style: StyleId | null) => void;
   onToggleAnimation: () => void;
+  onToggleAudio: () => void | Promise<void>;
 }
 
 const STYLE_IDS: StyleId[] = Object.values(STYLES).map((s) => s.id);
@@ -27,9 +29,11 @@ const MiniHud: React.FC<MiniHudProps> = ({
   manualStyle,
   effectiveStyle,
   isAnimating,
+  isAudioEnabled,
   onModeChange,
   onStyleChange,
   onToggleAnimation,
+  onToggleAudio,
 }) => {
   // which style do we *show*?
   // in manual mode, show manualStyle if set
@@ -49,7 +53,10 @@ const MiniHud: React.FC<MiniHudProps> = ({
     onStyleChange(nextId);
   }
 
-  const rootClass = "mini-hud" + (isAnimating ? " mini-hud--animating" : "");
+  const rootClass =
+    "mini-hud" +
+    (isAnimating ? " mini-hud--animating" : "") +
+    (isAudioEnabled ? " mini-hud--audio-on" : "");
 
   return (
     <div className={rootClass}>
@@ -76,6 +83,19 @@ const MiniHud: React.FC<MiniHudProps> = ({
       >
         <span className="mini-hud__dot" />
         <span className="mini-hud__text">{labelText}</span>
+      </button>
+
+      <button
+        type="button"
+        className="mini-hud__button mini-hud__button--sound"
+        aria-pressed={isAudioEnabled}
+        aria-label={isAudioEnabled ? "Stop sound" : "Start sound"}
+        onClick={() => {
+          void onToggleAudio();
+        }}
+        title={isAudioEnabled ? "Stop sound" : "Start sound"}
+      >
+        Sound
       </button>
 
       {/* Next button */}

--- a/src/hooks/useSonification.ts
+++ b/src/hooks/useSonification.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { buildAudioState, type AudioState } from "../logic/audioMapping";
+import type { GenerationState } from "../logic/types";
+
+interface UseSonificationResult {
+  audioState: AudioState;
+  isAudioEnabled: boolean;
+  audioVolume: number;
+  audioError: string | null;
+  toggleAudio: () => Promise<void>;
+  setAudioVolume: (volume: number) => void;
+}
+
+class SonificationEngine {
+  private context: AudioContext;
+  private masterGain: GainNode;
+  private timerId: number | null = null;
+  private audioState: AudioState;
+  private volume: number;
+  private noteIndex = 0;
+
+  constructor(audioState: AudioState, volume: number) {
+    this.context = new AudioContext();
+    this.masterGain = this.context.createGain();
+    this.masterGain.gain.value = audioState.masterGain * volume;
+    this.masterGain.connect(this.context.destination);
+    this.audioState = audioState;
+    this.volume = volume;
+  }
+
+  async start() {
+    await this.context.resume();
+    this.scheduleNext();
+  }
+
+  stop() {
+    if (this.timerId !== null) {
+      window.clearTimeout(this.timerId);
+      this.timerId = null;
+    }
+    this.masterGain.gain.setTargetAtTime(0, this.context.currentTime, 0.04);
+  }
+
+  close() {
+    this.stop();
+    void this.context.close();
+  }
+
+  updateAudioState(audioState: AudioState) {
+    this.audioState = audioState;
+    this.noteIndex = this.noteIndex % Math.max(1, audioState.notes.length);
+    this.masterGain.gain.setTargetAtTime(
+      audioState.masterGain * this.volume,
+      this.context.currentTime,
+      0.08
+    );
+  }
+
+  setVolume(volume: number) {
+    this.volume = volume;
+    this.masterGain.gain.setTargetAtTime(
+      this.audioState.masterGain * volume,
+      this.context.currentTime,
+      0.08
+    );
+  }
+
+  private scheduleNext = () => {
+    const note = this.audioState.notes[this.noteIndex];
+    if (!note) return;
+
+    this.playNote(note.frequency, note.duration, note.velocity, note.pan);
+    this.noteIndex = (this.noteIndex + 1) % this.audioState.notes.length;
+
+    const beatMs = 60_000 / this.audioState.tempo;
+    this.timerId = window.setTimeout(this.scheduleNext, beatMs);
+  };
+
+  private playNote(
+    frequency: number,
+    duration: number,
+    velocity: number,
+    pan: number
+  ) {
+    const now = this.context.currentTime;
+    const oscillator = this.context.createOscillator();
+    const voiceGain = this.context.createGain();
+    const filter = this.context.createBiquadFilter();
+    const panner = this.context.createStereoPanner();
+
+    oscillator.type = this.audioState.waveform;
+    oscillator.frequency.setValueAtTime(frequency, now);
+
+    filter.type = "lowpass";
+    filter.frequency.setTargetAtTime(
+      this.audioState.filterFrequency,
+      now,
+      0.03
+    );
+    filter.Q.value = 0.7;
+
+    panner.pan.setTargetAtTime(pan, now, 0.02);
+
+    voiceGain.gain.setValueAtTime(0.0001, now);
+    voiceGain.gain.exponentialRampToValueAtTime(
+      Math.max(0.0001, velocity),
+      now + 0.025
+    );
+    voiceGain.gain.exponentialRampToValueAtTime(
+      0.0001,
+      now + Math.max(0.06, duration)
+    );
+
+    oscillator.connect(filter);
+    filter.connect(panner);
+    panner.connect(voiceGain);
+    voiceGain.connect(this.masterGain);
+
+    oscillator.start(now);
+    oscillator.stop(now + duration + 0.04);
+  }
+}
+
+function clampVolume(volume: number): number {
+  return Math.max(0, Math.min(1, volume));
+}
+
+export function useSonification(
+  generationState: GenerationState
+): UseSonificationResult {
+  const [isAudioEnabled, setIsAudioEnabled] = useState(false);
+  const [audioVolume, setAudioVolumeState] = useState(0.55);
+  const [audioError, setAudioError] = useState<string | null>(null);
+  const engineRef = useRef<SonificationEngine | null>(null);
+
+  const audioState = useMemo(
+    () => buildAudioState(generationState),
+    [generationState]
+  );
+
+  useEffect(() => {
+    if (!engineRef.current) return;
+    engineRef.current.updateAudioState(audioState);
+  }, [audioState]);
+
+  useEffect(() => {
+    return () => {
+      engineRef.current?.close();
+      engineRef.current = null;
+    };
+  }, []);
+
+  const setAudioVolume = useCallback((volume: number) => {
+    const nextVolume = clampVolume(volume);
+    setAudioVolumeState(nextVolume);
+    engineRef.current?.setVolume(nextVolume);
+  }, []);
+
+  const toggleAudio = useCallback(async () => {
+    if (isAudioEnabled) {
+      engineRef.current?.close();
+      engineRef.current = null;
+      setIsAudioEnabled(false);
+      return;
+    }
+
+    try {
+      const engine = new SonificationEngine(audioState, audioVolume);
+      engineRef.current = engine;
+      await engine.start();
+      setAudioError(null);
+      setIsAudioEnabled(true);
+    } catch (error) {
+      engineRef.current?.close();
+      engineRef.current = null;
+      setIsAudioEnabled(false);
+      setAudioError(
+        error instanceof Error ? error.message : "Unable to start audio"
+      );
+    }
+  }, [audioState, audioVolume, isAudioEnabled]);
+
+  return {
+    audioState,
+    isAudioEnabled,
+    audioVolume,
+    audioError,
+    toggleAudio,
+    setAudioVolume,
+  };
+}

--- a/src/hooks/useSonification.ts
+++ b/src/hooks/useSonification.ts
@@ -14,15 +14,32 @@ interface UseSonificationResult {
 class SonificationEngine {
   private context: AudioContext;
   private masterGain: GainNode;
+  private echoGain: GainNode;
+  private echoDelay: DelayNode;
+  private echoFeedback: GainNode;
   private timerId: number | null = null;
+  private pendingTimerIds: number[] = [];
   private audioState: AudioState;
   private volume: number;
   private noteIndex = 0;
+  private rhythmIndex = 0;
 
   constructor(audioState: AudioState, volume: number) {
     this.context = new AudioContext();
     this.masterGain = this.context.createGain();
+    this.echoGain = this.context.createGain();
+    this.echoDelay = this.context.createDelay(1.5);
+    this.echoFeedback = this.context.createGain();
+
     this.masterGain.gain.value = audioState.masterGain * volume;
+    this.echoGain.gain.value = audioState.echoMix;
+    this.echoDelay.delayTime.value = audioState.echoTime;
+    this.echoFeedback.gain.value = 0.24;
+
+    this.echoDelay.connect(this.echoFeedback);
+    this.echoFeedback.connect(this.echoDelay);
+    this.echoDelay.connect(this.echoGain);
+    this.echoGain.connect(this.masterGain);
     this.masterGain.connect(this.context.destination);
     this.audioState = audioState;
     this.volume = volume;
@@ -38,6 +55,10 @@ class SonificationEngine {
       window.clearTimeout(this.timerId);
       this.timerId = null;
     }
+    for (const pendingTimerId of this.pendingTimerIds) {
+      window.clearTimeout(pendingTimerId);
+    }
+    this.pendingTimerIds = [];
     this.masterGain.gain.setTargetAtTime(0, this.context.currentTime, 0.04);
   }
 
@@ -49,8 +70,19 @@ class SonificationEngine {
   updateAudioState(audioState: AudioState) {
     this.audioState = audioState;
     this.noteIndex = this.noteIndex % Math.max(1, audioState.notes.length);
+    this.rhythmIndex = this.rhythmIndex % Math.max(1, audioState.rhythm.length);
     this.masterGain.gain.setTargetAtTime(
       audioState.masterGain * this.volume,
+      this.context.currentTime,
+      0.08
+    );
+    this.echoGain.gain.setTargetAtTime(
+      audioState.echoMix,
+      this.context.currentTime,
+      0.08
+    );
+    this.echoDelay.delayTime.setTargetAtTime(
+      audioState.echoTime,
       this.context.currentTime,
       0.08
     );
@@ -69,18 +101,96 @@ class SonificationEngine {
     const note = this.audioState.notes[this.noteIndex];
     if (!note) return;
 
-    this.playNote(note.frequency, note.duration, note.velocity, note.pan);
-    this.noteIndex = (this.noteIndex + 1) % this.audioState.notes.length;
-
     const beatMs = 60_000 / this.audioState.tempo;
-    this.timerId = window.setTimeout(this.scheduleNext, beatMs);
+    this.playPatternNote(note);
+
+    if (this.shouldPlayChord()) {
+      this.playChord(note.duration);
+    }
+
+    this.noteIndex = (this.noteIndex + 1) % this.audioState.notes.length;
+    const rhythm = this.audioState.rhythm[this.rhythmIndex] ?? 1;
+    this.rhythmIndex = (this.rhythmIndex + 1) % this.audioState.rhythm.length;
+
+    this.timerId = window.setTimeout(this.scheduleNext, beatMs * rhythm);
   };
+
+  private shouldPlayChord(): boolean {
+    if (this.audioState.mode === "drone") return this.noteIndex % 2 === 0;
+    if (this.audioState.mode === "pulse") return this.noteIndex % 4 === 0;
+    if (this.audioState.mode === "flow") return this.noteIndex % 5 === 0;
+    return false;
+  }
+
+  private playPatternNote(note: AudioState["notes"][number]) {
+    const accentBoost = note.accent ? 1.22 : 1;
+    this.playNote(
+      note.frequency,
+      note.duration,
+      note.velocity * accentBoost,
+      note.pan,
+      this.audioState.waveform,
+      note.accent
+    );
+
+    if (this.audioState.mode === "branch" && note.accent) {
+      this.scheduleAccent(() => {
+        this.playNote(
+          note.frequency * 1.5,
+          note.duration * 0.58,
+          note.velocity * 0.58,
+          -note.pan,
+          "triangle",
+          false
+        );
+      }, 90);
+    }
+
+    if (this.audioState.mode === "sparkle" && note.accent) {
+      this.scheduleAccent(() => {
+        this.playNote(
+          note.frequency * 2,
+          note.duration * 0.45,
+          note.velocity * 0.45,
+          -note.pan,
+          "sine",
+          false
+        );
+      }, 55);
+    }
+  }
+
+  private scheduleAccent(callback: () => void, delay: number) {
+    const timerId = window.setTimeout(() => {
+      this.pendingTimerIds = this.pendingTimerIds.filter((id) => id !== timerId);
+      callback();
+    }, delay);
+    this.pendingTimerIds.push(timerId);
+  }
+
+  private playChord(duration: number) {
+    const chordDuration =
+      this.audioState.mode === "drone" ? duration * 1.8 : duration * 1.15;
+
+    this.audioState.chordFrequencies.forEach((frequency, index) => {
+      this.playNote(
+        frequency,
+        chordDuration,
+        this.audioState.mode === "drone" ? 0.26 : 0.18,
+        (index - 1) * 0.35,
+        this.audioState.waveform,
+        false
+      );
+    });
+  }
 
   private playNote(
     frequency: number,
     duration: number,
     velocity: number,
-    pan: number
+    pan: number,
+    waveform: OscillatorType,
+    accent: boolean
   ) {
     const now = this.context.currentTime;
     const oscillator = this.context.createOscillator();
@@ -88,7 +198,7 @@ class SonificationEngine {
     const filter = this.context.createBiquadFilter();
     const panner = this.context.createStereoPanner();
 
-    oscillator.type = this.audioState.waveform;
+    oscillator.type = waveform;
     oscillator.frequency.setValueAtTime(frequency, now);
 
     filter.type = "lowpass";
@@ -97,27 +207,30 @@ class SonificationEngine {
       now,
       0.03
     );
-    filter.Q.value = 0.7;
+    filter.Q.value = accent
+      ? this.audioState.filterQ * 1.25
+      : this.audioState.filterQ;
 
     panner.pan.setTargetAtTime(pan, now, 0.02);
 
     voiceGain.gain.setValueAtTime(0.0001, now);
     voiceGain.gain.exponentialRampToValueAtTime(
-      Math.max(0.0001, velocity),
-      now + 0.025
+      Math.max(0.0001, Math.min(1, velocity)),
+      now + this.audioState.attack
     );
     voiceGain.gain.exponentialRampToValueAtTime(
       0.0001,
-      now + Math.max(0.06, duration)
+      now + Math.max(0.06, duration + this.audioState.release)
     );
 
     oscillator.connect(filter);
     filter.connect(panner);
     panner.connect(voiceGain);
     voiceGain.connect(this.masterGain);
+    voiceGain.connect(this.echoDelay);
 
     oscillator.start(now);
-    oscillator.stop(now + duration + 0.04);
+    oscillator.stop(now + duration + this.audioState.release + 0.04);
   }
 }
 

--- a/src/logic/audioMapping.ts
+++ b/src/logic/audioMapping.ts
@@ -2,20 +2,39 @@ import type { GenerationState, StyleId } from "./types";
 import { makeRng } from "./rng";
 
 export type OscillatorVoice = OscillatorType;
+export type AudioMode =
+  | "pulse"
+  | "drone"
+  | "sparkle"
+  | "pluck"
+  | "wave"
+  | "grid"
+  | "bloom"
+  | "branch"
+  | "flow";
 
 export interface AudioNote {
   frequency: number;
   duration: number;
   velocity: number;
   pan: number;
+  accent: boolean;
 }
 
 export interface AudioState {
   styleId: StyleId;
+  mode: AudioMode;
   tempo: number;
   masterGain: number;
   filterFrequency: number;
+  filterQ: number;
   waveform: OscillatorVoice;
+  attack: number;
+  release: number;
+  echoMix: number;
+  echoTime: number;
+  rhythm: number[];
+  chordFrequencies: number[];
   notes: AudioNote[];
   summary: string;
 }
@@ -26,28 +45,338 @@ interface HslColor {
   lightness: number;
 }
 
-const STYLE_WAVEFORMS: Partial<Record<StyleId, OscillatorVoice>> = {
-  orbits: "sine",
-  strata: "triangle",
-  constellation: "sine",
-  bubbles: "sine",
-  waves: "triangle",
-  supershape: "sawtooth",
-  isogrid: "square",
-  crystal: "triangle",
-  lattice: "square",
-  nebula: "sine",
-  aurora: "sine",
-  voronoi: "sawtooth",
-  fern: "triangle",
-  koch: "triangle",
-  tree: "triangle",
-  flowfield: "sine",
-};
+interface StyleAudioProfile {
+  mode: AudioMode;
+  waveform: OscillatorVoice;
+  scale: number[];
+  tempoBase: number;
+  tempoRange: number;
+  noteBase: number;
+  noteRange: number;
+  durationBase: number;
+  durationRange: number;
+  attack: number;
+  release: number;
+  filterBase: number;
+  filterRange: number;
+  filterQ: number;
+  echoMix: number;
+  echoTime: number;
+  rootOffset: number;
+  octaveChance: number;
+  rhythm: number[];
+  chord: number[];
+}
 
 const MAJOR_PENTATONIC = [0, 2, 4, 7, 9, 12, 14, 16];
 const MINOR_PENTATONIC = [0, 3, 5, 7, 10, 12, 15, 17];
 const LYDIAN = [0, 2, 4, 6, 7, 9, 11, 12];
+const WHOLE_TONE = [0, 2, 4, 6, 8, 10, 12, 14];
+const HARMONIC_MINOR = [0, 2, 3, 7, 8, 11, 12, 15];
+const OCTATONIC = [0, 2, 3, 5, 6, 8, 9, 11, 12];
+
+const DEFAULT_PROFILE: StyleAudioProfile = {
+  mode: "pulse",
+  waveform: "sine",
+  scale: MAJOR_PENTATONIC,
+  tempoBase: 64,
+  tempoRange: 52,
+  noteBase: 4,
+  noteRange: 6,
+  durationBase: 0.2,
+  durationRange: 0.34,
+  attack: 0.025,
+  release: 0.14,
+  filterBase: 700,
+  filterRange: 2600,
+  filterQ: 0.8,
+  echoMix: 0.18,
+  echoTime: 0.28,
+  rootOffset: 0,
+  octaveChance: 0.22,
+  rhythm: [1, 1, 1.5, 0.5],
+  chord: [0, 7, 12],
+};
+
+const STYLE_PROFILES: Partial<Record<StyleId, StyleAudioProfile>> = {
+  orbits: {
+    ...DEFAULT_PROFILE,
+    mode: "pulse",
+    waveform: "sine",
+    scale: MAJOR_PENTATONIC,
+    tempoBase: 48,
+    tempoRange: 38,
+    durationBase: 0.32,
+    durationRange: 0.46,
+    attack: 0.04,
+    release: 0.22,
+    echoMix: 0.28,
+    echoTime: 0.42,
+    rhythm: [1.5, 1, 1.5, 2],
+    chord: [0, 7, 12],
+  },
+  strata: {
+    ...DEFAULT_PROFILE,
+    mode: "drone",
+    waveform: "triangle",
+    scale: HARMONIC_MINOR,
+    tempoBase: 36,
+    tempoRange: 28,
+    noteBase: 3,
+    noteRange: 4,
+    durationBase: 0.8,
+    durationRange: 1.2,
+    attack: 0.18,
+    release: 0.55,
+    filterBase: 420,
+    filterRange: 1200,
+    echoMix: 0.34,
+    echoTime: 0.65,
+    rootOffset: -7,
+    rhythm: [2, 3, 1.5],
+    chord: [0, 3, 10],
+  },
+  constellation: {
+    ...DEFAULT_PROFILE,
+    mode: "sparkle",
+    waveform: "sine",
+    scale: LYDIAN,
+    tempoBase: 78,
+    tempoRange: 78,
+    noteBase: 6,
+    noteRange: 8,
+    durationBase: 0.08,
+    durationRange: 0.18,
+    attack: 0.006,
+    release: 0.18,
+    filterBase: 1800,
+    filterRange: 3600,
+    filterQ: 1.2,
+    echoMix: 0.42,
+    echoTime: 0.18,
+    rootOffset: 12,
+    octaveChance: 0.48,
+    rhythm: [0.5, 0.5, 1, 0.25, 0.75],
+    chord: [0, 4, 11],
+  },
+  bubbles: {
+    ...DEFAULT_PROFILE,
+    mode: "pluck",
+    waveform: "sine",
+    scale: MAJOR_PENTATONIC,
+    tempoBase: 68,
+    tempoRange: 58,
+    durationBase: 0.1,
+    durationRange: 0.22,
+    attack: 0.008,
+    release: 0.12,
+    filterBase: 1100,
+    filterRange: 2300,
+    echoMix: 0.25,
+    echoTime: 0.22,
+    rootOffset: 5,
+    octaveChance: 0.36,
+    rhythm: [0.75, 0.5, 1.25, 0.5],
+    chord: [0, 7, 14],
+  },
+  waves: {
+    ...DEFAULT_PROFILE,
+    mode: "wave",
+    waveform: "triangle",
+    scale: MINOR_PENTATONIC,
+    tempoBase: 52,
+    tempoRange: 44,
+    durationBase: 0.42,
+    durationRange: 0.65,
+    attack: 0.09,
+    release: 0.36,
+    filterBase: 650,
+    filterRange: 1900,
+    echoMix: 0.36,
+    echoTime: 0.5,
+    rhythm: [1, 2, 0.75, 1.25],
+    chord: [0, 5, 12],
+  },
+  supershape: {
+    ...DEFAULT_PROFILE,
+    mode: "bloom",
+    waveform: "sawtooth",
+    scale: WHOLE_TONE,
+    tempoBase: 70,
+    tempoRange: 64,
+    filterQ: 1.4,
+    rootOffset: 7,
+    rhythm: [1, 0.5, 0.5, 1.5],
+    chord: [0, 4, 8],
+  },
+  isogrid: {
+    ...DEFAULT_PROFILE,
+    mode: "grid",
+    waveform: "square",
+    scale: OCTATONIC,
+    tempoBase: 88,
+    tempoRange: 70,
+    durationBase: 0.06,
+    durationRange: 0.14,
+    attack: 0.004,
+    release: 0.08,
+    filterBase: 900,
+    filterRange: 2600,
+    filterQ: 1.6,
+    echoMix: 0.16,
+    echoTime: 0.16,
+    rhythm: [0.5, 0.5, 0.5, 1],
+    chord: [0, 6, 9],
+  },
+  crystal: {
+    ...DEFAULT_PROFILE,
+    mode: "sparkle",
+    waveform: "triangle",
+    scale: LYDIAN,
+    tempoBase: 72,
+    tempoRange: 84,
+    durationBase: 0.09,
+    durationRange: 0.2,
+    attack: 0.005,
+    release: 0.22,
+    filterBase: 1600,
+    filterRange: 3300,
+    filterQ: 1.8,
+    echoMix: 0.46,
+    echoTime: 0.24,
+    rootOffset: 10,
+    octaveChance: 0.5,
+    rhythm: [0.5, 1, 0.5, 0.25, 0.75],
+    chord: [0, 6, 12],
+  },
+  lattice: {
+    ...DEFAULT_PROFILE,
+    mode: "grid",
+    waveform: "square",
+    scale: OCTATONIC,
+    tempoBase: 76,
+    tempoRange: 68,
+    filterQ: 1.5,
+    rhythm: [0.75, 0.75, 1, 0.5],
+    chord: [0, 3, 9],
+  },
+  nebula: {
+    ...DEFAULT_PROFILE,
+    mode: "drone",
+    waveform: "sine",
+    scale: LYDIAN,
+    tempoBase: 34,
+    tempoRange: 24,
+    durationBase: 1.0,
+    durationRange: 1.4,
+    attack: 0.22,
+    release: 0.8,
+    filterBase: 500,
+    filterRange: 1500,
+    echoMix: 0.48,
+    echoTime: 0.72,
+    rootOffset: -12,
+    rhythm: [3, 2, 4],
+    chord: [0, 7, 11],
+  },
+  aurora: {
+    ...DEFAULT_PROFILE,
+    mode: "flow",
+    waveform: "sine",
+    scale: LYDIAN,
+    tempoBase: 46,
+    tempoRange: 50,
+    durationBase: 0.56,
+    durationRange: 0.9,
+    attack: 0.14,
+    release: 0.58,
+    filterBase: 900,
+    filterRange: 2500,
+    echoMix: 0.44,
+    echoTime: 0.55,
+    rootOffset: 3,
+    rhythm: [1.5, 0.75, 1.25, 2],
+    chord: [0, 6, 11],
+  },
+  voronoi: {
+    ...DEFAULT_PROFILE,
+    mode: "bloom",
+    waveform: "sawtooth",
+    scale: WHOLE_TONE,
+    tempoBase: 58,
+    tempoRange: 56,
+    durationBase: 0.22,
+    durationRange: 0.6,
+    attack: 0.045,
+    release: 0.3,
+    filterQ: 1.2,
+    echoMix: 0.34,
+    rhythm: [1, 0.5, 1.5, 0.5],
+    chord: [0, 4, 8],
+  },
+  fern: {
+    ...DEFAULT_PROFILE,
+    mode: "branch",
+    waveform: "triangle",
+    scale: MINOR_PENTATONIC,
+    tempoBase: 60,
+    tempoRange: 58,
+    durationBase: 0.16,
+    durationRange: 0.38,
+    attack: 0.018,
+    release: 0.2,
+    echoMix: 0.28,
+    echoTime: 0.31,
+    rootOffset: -5,
+    rhythm: [0.75, 0.75, 0.5, 1.25],
+    chord: [0, 7, 15],
+  },
+  koch: {
+    ...DEFAULT_PROFILE,
+    mode: "sparkle",
+    waveform: "triangle",
+    scale: OCTATONIC,
+    tempoBase: 66,
+    tempoRange: 70,
+    filterQ: 1.7,
+    rootOffset: 8,
+    rhythm: [1, 0.5, 0.5, 0.5],
+    chord: [0, 6, 12],
+  },
+  tree: {
+    ...DEFAULT_PROFILE,
+    mode: "branch",
+    waveform: "triangle",
+    scale: HARMONIC_MINOR,
+    tempoBase: 50,
+    tempoRange: 54,
+    durationBase: 0.2,
+    durationRange: 0.48,
+    attack: 0.035,
+    release: 0.28,
+    rootOffset: -10,
+    rhythm: [1, 0.5, 0.75, 1.5],
+    chord: [0, 7, 12],
+  },
+  flowfield: {
+    ...DEFAULT_PROFILE,
+    mode: "flow",
+    waveform: "sine",
+    scale: LYDIAN,
+    tempoBase: 54,
+    tempoRange: 48,
+    durationBase: 0.36,
+    durationRange: 0.72,
+    attack: 0.08,
+    release: 0.38,
+    filterBase: 800,
+    filterRange: 2600,
+    echoMix: 0.38,
+    echoTime: 0.4,
+    rhythm: [0.75, 1.25, 0.75, 1.75],
+    chord: [0, 6, 9],
+  },
+};
 
 function clamp(min: number, max: number, value: number): number {
   return Math.max(min, Math.min(max, value));
@@ -95,60 +424,70 @@ function frequencyFromSemitone(rootFrequency: number, semitone: number): number 
   return rootFrequency * Math.pow(2, semitone / 12);
 }
 
-function getScale(styleId: StyleId): number[] {
-  if (styleId === "strata" || styleId === "tree" || styleId === "fern") {
-    return MINOR_PENTATONIC;
-  }
-  if (styleId === "aurora" || styleId === "nebula" || styleId === "flowfield") {
-    return LYDIAN;
-  }
-  return MAJOR_PENTATONIC;
-}
-
 export function buildAudioState(state: GenerationState): AudioState {
   const rng = makeRng(state.seed + 13_371);
   const paletteAverage = averagePalette(state.palette);
   const complexity = clamp(0, 1, state.complexity / 100);
-  const scale = getScale(state.styleId);
+  const profile = STYLE_PROFILES[state.styleId] ?? DEFAULT_PROFILE;
+  const scale = profile.scale;
 
-  const baseMidi = 45 + Math.round((paletteAverage.hue / 360) * 18);
+  const baseMidi =
+    45 + Math.round((paletteAverage.hue / 360) * 18) + profile.rootOffset;
   const rootFrequency = frequencyFromSemitone(440, baseMidi - 69);
-  const tempo = Math.round(48 + complexity * 72 + rng() * 10);
-  const noteCount = Math.round(3 + complexity * 7);
+  const tempo = Math.round(
+    profile.tempoBase + complexity * profile.tempoRange + rng() * 8
+  );
+  const noteCount = Math.round(profile.noteBase + complexity * profile.noteRange);
   const filterFrequency = Math.round(
-    600 + (paletteAverage.lightness / 100) * 2200 + complexity * 1200
+    profile.filterBase +
+      (paletteAverage.lightness / 100) * profile.filterRange +
+      complexity * profile.filterRange * 0.45
   );
   const masterGain = clamp(
     0.03,
-    0.16,
-    0.06 + (paletteAverage.saturation / 100) * 0.06 + complexity * 0.04
+    0.18,
+    0.055 + (paletteAverage.saturation / 100) * 0.065 + complexity * 0.05
+  );
+  const chordFrequencies = profile.chord.map((degree) =>
+    frequencyFromSemitone(rootFrequency, degree)
   );
 
   const notes: AudioNote[] = [];
   for (let i = 0; i < noteCount; i++) {
     const degree = scale[Math.floor(rng() * scale.length)] ?? 0;
-    const octave = rng() > 0.78 ? 12 : 0;
-    const duration = 0.18 + rng() * (0.34 + complexity * 0.28);
+    const octave = rng() < profile.octaveChance ? 12 : 0;
+    const duration =
+      profile.durationBase + rng() * (profile.durationRange + complexity * 0.24);
     const velocity = 0.45 + rng() * (0.35 + complexity * 0.15);
     const pan = clamp(-0.8, 0.8, (rng() - 0.5) * (0.6 + complexity));
+    const accent = i % Math.max(2, Math.round(5 - complexity * 3)) === 0;
 
     notes.push({
       frequency: frequencyFromSemitone(rootFrequency, degree + octave),
       duration,
       velocity,
       pan,
+      accent,
     });
   }
 
   return {
     styleId: state.styleId,
+    mode: profile.mode,
     tempo,
     masterGain,
     filterFrequency,
-    waveform: STYLE_WAVEFORMS[state.styleId] ?? "sine",
+    filterQ: profile.filterQ,
+    waveform: profile.waveform,
+    attack: profile.attack,
+    release: profile.release,
+    echoMix: profile.echoMix,
+    echoTime: profile.echoTime,
+    rhythm: profile.rhythm,
+    chordFrequencies,
     notes,
     summary:
-      `${state.styleId} sound: ${tempo} BPM, ${notes.length} notes, ` +
+      `${state.styleId} ${profile.mode}: ${tempo} BPM, ${notes.length} notes, ` +
       `${Math.round(filterFrequency)} Hz brightness`,
   };
 }

--- a/src/logic/audioMapping.ts
+++ b/src/logic/audioMapping.ts
@@ -1,0 +1,154 @@
+import type { GenerationState, StyleId } from "./types";
+import { makeRng } from "./rng";
+
+export type OscillatorVoice = OscillatorType;
+
+export interface AudioNote {
+  frequency: number;
+  duration: number;
+  velocity: number;
+  pan: number;
+}
+
+export interface AudioState {
+  styleId: StyleId;
+  tempo: number;
+  masterGain: number;
+  filterFrequency: number;
+  waveform: OscillatorVoice;
+  notes: AudioNote[];
+  summary: string;
+}
+
+interface HslColor {
+  hue: number;
+  saturation: number;
+  lightness: number;
+}
+
+const STYLE_WAVEFORMS: Partial<Record<StyleId, OscillatorVoice>> = {
+  orbits: "sine",
+  strata: "triangle",
+  constellation: "sine",
+  bubbles: "sine",
+  waves: "triangle",
+  supershape: "sawtooth",
+  isogrid: "square",
+  crystal: "triangle",
+  lattice: "square",
+  nebula: "sine",
+  aurora: "sine",
+  voronoi: "sawtooth",
+  fern: "triangle",
+  koch: "triangle",
+  tree: "triangle",
+  flowfield: "sine",
+};
+
+const MAJOR_PENTATONIC = [0, 2, 4, 7, 9, 12, 14, 16];
+const MINOR_PENTATONIC = [0, 3, 5, 7, 10, 12, 15, 17];
+const LYDIAN = [0, 2, 4, 6, 7, 9, 11, 12];
+
+function clamp(min: number, max: number, value: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function parseHslColor(color: string): HslColor | null {
+  const match = color.match(
+    /^hsl\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)$/i
+  );
+  if (!match) return null;
+
+  return {
+    hue: Number(match[1]),
+    saturation: Number(match[2]),
+    lightness: Number(match[3]),
+  };
+}
+
+function averagePalette(palette: string[]): HslColor {
+  const parsed = palette
+    .map(parseHslColor)
+    .filter((color): color is HslColor => color !== null);
+
+  if (!parsed.length) {
+    return { hue: 180, saturation: 55, lightness: 50 };
+  }
+
+  const totals = parsed.reduce(
+    (sum, color) => ({
+      hue: sum.hue + color.hue,
+      saturation: sum.saturation + color.saturation,
+      lightness: sum.lightness + color.lightness,
+    }),
+    { hue: 0, saturation: 0, lightness: 0 }
+  );
+
+  return {
+    hue: totals.hue / parsed.length,
+    saturation: totals.saturation / parsed.length,
+    lightness: totals.lightness / parsed.length,
+  };
+}
+
+function frequencyFromSemitone(rootFrequency: number, semitone: number): number {
+  return rootFrequency * Math.pow(2, semitone / 12);
+}
+
+function getScale(styleId: StyleId): number[] {
+  if (styleId === "strata" || styleId === "tree" || styleId === "fern") {
+    return MINOR_PENTATONIC;
+  }
+  if (styleId === "aurora" || styleId === "nebula" || styleId === "flowfield") {
+    return LYDIAN;
+  }
+  return MAJOR_PENTATONIC;
+}
+
+export function buildAudioState(state: GenerationState): AudioState {
+  const rng = makeRng(state.seed + 13_371);
+  const paletteAverage = averagePalette(state.palette);
+  const complexity = clamp(0, 1, state.complexity / 100);
+  const scale = getScale(state.styleId);
+
+  const baseMidi = 45 + Math.round((paletteAverage.hue / 360) * 18);
+  const rootFrequency = frequencyFromSemitone(440, baseMidi - 69);
+  const tempo = Math.round(48 + complexity * 72 + rng() * 10);
+  const noteCount = Math.round(3 + complexity * 7);
+  const filterFrequency = Math.round(
+    600 + (paletteAverage.lightness / 100) * 2200 + complexity * 1200
+  );
+  const masterGain = clamp(
+    0.03,
+    0.16,
+    0.06 + (paletteAverage.saturation / 100) * 0.06 + complexity * 0.04
+  );
+
+  const notes: AudioNote[] = [];
+  for (let i = 0; i < noteCount; i++) {
+    const degree = scale[Math.floor(rng() * scale.length)] ?? 0;
+    const octave = rng() > 0.78 ? 12 : 0;
+    const duration = 0.18 + rng() * (0.34 + complexity * 0.28);
+    const velocity = 0.45 + rng() * (0.35 + complexity * 0.15);
+    const pan = clamp(-0.8, 0.8, (rng() - 0.5) * (0.6 + complexity));
+
+    notes.push({
+      frequency: frequencyFromSemitone(rootFrequency, degree + octave),
+      duration,
+      velocity,
+      pan,
+    });
+  }
+
+  return {
+    styleId: state.styleId,
+    tempo,
+    masterGain,
+    filterFrequency,
+    waveform: STYLE_WAVEFORMS[state.styleId] ?? "sine",
+    notes,
+    summary:
+      `${state.styleId} sound: ${tempo} BPM, ${notes.length} notes, ` +
+      `${Math.round(filterFrequency)} Hz brightness`,
+  };
+}

--- a/tests/logic/audioMapping.test.ts
+++ b/tests/logic/audioMapping.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { buildGenerationState } from "../../src/logic/generation";
+import { buildAudioState } from "../../src/logic/audioMapping";
+import type { GenerationOptions, UserTraits } from "../../src/logic/types";
+
+const traits: UserTraits = {
+  timeZone: "America/New_York",
+  userAgent: "Mozilla/5.0 Firefox/121.0",
+  language: "en-US",
+  screenWidth: 1440,
+  screenHeight: 900,
+  devicePixelRatio: 2,
+  darkMode: true,
+  ipInfo: {
+    ip: "198.51.100.88",
+    city: "Example City",
+    region: "Example Region",
+    country: "Example Country",
+    continentCode: "NA",
+  },
+};
+
+const options: GenerationOptions = {
+  mode: "manual",
+  manualSeed: 42,
+  manualStyle: "tree",
+  complexity: 60,
+  paletteShift: 0,
+};
+
+describe("buildAudioState", () => {
+  it("is deterministic for the same generation state", () => {
+    const generation = buildGenerationState(traits, options);
+
+    expect(buildAudioState(generation)).toEqual(buildAudioState(generation));
+  });
+
+  it("maps complexity to denser and faster sound", () => {
+    const low = buildAudioState(
+      buildGenerationState(traits, { ...options, complexity: 10 })
+    );
+    const high = buildAudioState(
+      buildGenerationState(traits, { ...options, complexity: 95 })
+    );
+
+    expect(high.tempo).toBeGreaterThan(low.tempo);
+    expect(high.notes.length).toBeGreaterThan(low.notes.length);
+  });
+
+  it("keeps generated sound parameters in conservative ranges", () => {
+    const audio = buildAudioState(buildGenerationState(traits, options));
+
+    expect(audio.masterGain).toBeGreaterThanOrEqual(0.03);
+    expect(audio.masterGain).toBeLessThanOrEqual(0.16);
+    expect(audio.filterFrequency).toBeGreaterThanOrEqual(600);
+    expect(audio.notes.length).toBeGreaterThanOrEqual(3);
+    expect(audio.notes.length).toBeLessThanOrEqual(10);
+    for (const note of audio.notes) {
+      expect(note.frequency).toBeGreaterThan(50);
+      expect(note.frequency).toBeLessThan(2000);
+      expect(note.pan).toBeGreaterThanOrEqual(-0.8);
+      expect(note.pan).toBeLessThanOrEqual(0.8);
+    }
+  });
+});

--- a/tests/logic/audioMapping.test.ts
+++ b/tests/logic/audioMapping.test.ts
@@ -51,15 +51,47 @@ describe("buildAudioState", () => {
     const audio = buildAudioState(buildGenerationState(traits, options));
 
     expect(audio.masterGain).toBeGreaterThanOrEqual(0.03);
-    expect(audio.masterGain).toBeLessThanOrEqual(0.16);
-    expect(audio.filterFrequency).toBeGreaterThanOrEqual(600);
+    expect(audio.masterGain).toBeLessThanOrEqual(0.18);
+    expect(audio.filterFrequency).toBeGreaterThanOrEqual(400);
     expect(audio.notes.length).toBeGreaterThanOrEqual(3);
-    expect(audio.notes.length).toBeLessThanOrEqual(10);
+    expect(audio.notes.length).toBeLessThanOrEqual(14);
+    expect(audio.rhythm.length).toBeGreaterThan(0);
+    expect(audio.chordFrequencies.length).toBeGreaterThan(0);
     for (const note of audio.notes) {
       expect(note.frequency).toBeGreaterThan(50);
       expect(note.frequency).toBeLessThan(2000);
       expect(note.pan).toBeGreaterThanOrEqual(-0.8);
       expect(note.pan).toBeLessThanOrEqual(0.8);
     }
+  });
+
+  it("gives visual styles distinct audio modes and profiles", () => {
+    const styleIds = [
+      "orbits",
+      "strata",
+      "constellation",
+      "bubbles",
+      "waves",
+      "isogrid",
+      "tree",
+      "flowfield",
+    ] as const;
+
+    const states = styleIds.map((manualStyle) =>
+      buildAudioState(
+        buildGenerationState(traits, {
+          ...options,
+          manualStyle,
+        })
+      )
+    );
+
+    const modes = new Set(states.map((state) => state.mode));
+    const waveforms = new Set(states.map((state) => state.waveform));
+    const summaries = new Set(states.map((state) => state.summary));
+
+    expect(modes.size).toBeGreaterThanOrEqual(6);
+    expect(waveforms.size).toBeGreaterThanOrEqual(3);
+    expect(summaries.size).toBe(styleIds.length);
   });
 });


### PR DESCRIPTION
## Summary
- Add Web Audio sonification derived from the same generation state as the visuals
- Add a visible Sound toggle in the MiniHud and sound controls in the ControlPanel
- Add richer style-specific audio profiles for distinct visual/audio pairings
- Add unit tests for deterministic audio mapping and style-profile variation

## Details
Sonification now maps `GenerationState` into deterministic audio parameters:
- style-specific sound mode
- tempo and rhythm pattern
- waveform
- note sequence
- chord/drone accents
- filter brightness and resonance
- stereo pan
- echo timing and mix
- master gain

Audio starts only after user interaction, matching browser autoplay rules. The richer Phase 3B profiles make styles feel more correlated with their visuals: orbits pulse, strata drones, constellations sparkle, grids tick, branches echo, and flow styles drift.

## Verification
- `npm run ci`
- Manual browser test: Sound starts/stops from MiniHud
- Manual browser test: volume control works
- Manual browser test: multiple styles produce noticeably different sound profiles