### PR TITLE
Improve accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Audio profiles are designed to loosely match the visual language: orbits pulse, 
 
 Audio starts only after a button press, matching browser autoplay rules.
 
+### ♿ Accessibility
+
+DatArt includes a screen-reader summary of the current artwork and sound state. The summary includes style, mode, complexity, animation state, reduced-motion status, sound state, audio profile, and palette count.
+
+Keyboard support:
+- Tab reaches the corner toggles, MiniHud controls, style controls, sound controls, and debug controls.
+- Enter or Space activates buttons and toggles.
+- Escape closes the controls or debug panel when either is open.
+- If reduced motion is requested, the app starts with animation off unless the visitor explicitly turns animation on.
+
 ### 🪩 Debug Panel
 
 Shows:
@@ -92,6 +102,7 @@ src/
     useIpInfo.ts
     useSonification.ts
   logic/
+    accessibilitySummary.ts
     audioMapping.ts
     fingerprint.ts
     generation.ts
@@ -150,6 +161,16 @@ npm run test
 npm run ci
 ```
 This runs lint, TypeScript type-checking for app and test files, unit tests, and the production build. Use this before pushing to `main`, since Netlify deploys from that branch.
+
+### Manual accessibility check
+
+Before a demo or deploy:
+- Navigate the app with only the keyboard.
+- Confirm focus outlines are visible.
+- Confirm Escape closes open panels.
+- Confirm Sound starts only after pressing a sound button.
+- Confirm reduced-motion mode starts with animation off.
+- With a screen reader, confirm the generated artwork and sound summary is announced.
 
 ### Preview the production build
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,6 +131,8 @@ Phase 3B notes:
 
 ## Phase 4: Accessibility And Presentation Polish
 
+Status: first accessibility pass implemented on `feat/a11y`
+
 Priority: medium
 
 Tasks:
@@ -150,6 +152,16 @@ Suggested acceptance checks:
 - Reduced-motion preference disables or softens complexity animation by default.
 - README setup instructions match the current app.
 
+Implemented notes:
+
+- Added `buildAccessibilitySummary()` to describe style, generation mode, complexity, motion state, sound state, audio profile, and palette count.
+- Rendered the summary in an `aria-live` screen-reader-only region.
+- Reduced-motion users start with animation off unless they explicitly turn animation on.
+- MiniHud controls now expose clearer `aria-label` and `aria-pressed` state.
+- Controls and debug toggles now expose `aria-expanded`, `aria-controls`, dialog roles, and Escape-to-close behavior.
+- Added visible focus outlines and larger inner control targets.
+- Unit tests cover the accessibility summary helper.
+
 ## Phase 5: Optional Improvements After The Demo
 
 Priority: lower
@@ -165,7 +177,7 @@ Ideas:
 
 ## Suggested Next Steps
 
-1. Manually test sound start/stop and volume in Chrome, Safari, Firefox, and at least one mobile browser.
-2. Tune each style's sound personality for the demo: orbits, strata, constellation, bubbles, waves, tree, aurora, nebula, and flowfield should be clearly distinguishable.
-3. Add a concise screen-reader summary that includes both visual style and sound state.
+1. Manually test keyboard-only navigation on desktop and mobile-sized layouts.
+2. Test with at least one screen reader and confirm the live summary is useful without being too chatty.
+3. Manually verify reduced-motion startup behavior in the browser.
 4. Do a timed rehearsal on the actual demo machine or a similar laptop, with browser devtools memory/performance open.

--- a/src/App.css
+++ b/src/App.css
@@ -25,6 +25,18 @@ body,
   overflow: hidden;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .art-label {
   position: absolute;
   left: 1rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import type {
 } from './logic/types';
 
 import { buildGenerationState, } from './logic/generation';
+import { buildAccessibilitySummary } from "./logic/accessibilitySummary";
 import { getBaseTraits, applyIpInfo } from "./logic/fingerprint";
 import DebugPanel from "./components/ui/DebugPanel";
 import ControlPanel from "./components/ui/ControlPanel";
@@ -37,6 +38,7 @@ const App: React.FC = () => {
   const [hudHidden, setHudHidden] = useState(false);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const complexityDirectionRef = useRef<1 | -1>(1);
+  const animationUserOverrideRef = useRef(false);
   
   const { ipInfo, loading: ipLoaded, error: ipError } = useIpInfo();
   const isMobile = useIsMobile();
@@ -66,12 +68,36 @@ const App: React.FC = () => {
     toggleAudio,
     setAudioVolume,
   } = useSonification(generationState);
+  const accessibilitySummary = useMemo(
+    () =>
+      buildAccessibilitySummary({
+        generationState,
+        audioState,
+        isAnimating,
+        isAudioEnabled,
+        audioVolume,
+        prefersReducedMotion,
+      }),
+    [
+      audioState,
+      audioVolume,
+      generationState,
+      isAnimating,
+      isAudioEnabled,
+      prefersReducedMotion,
+    ]
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const query = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const update = () => setPrefersReducedMotion(query.matches);
+    const update = () => {
+      setPrefersReducedMotion(query.matches);
+      if (query.matches && !animationUserOverrideRef.current) {
+        setIsAnimating(false);
+      }
+    };
 
     update();
     query.addEventListener("change", update);
@@ -169,12 +195,16 @@ const App: React.FC = () => {
     }));
 
   const handleToggleAnimation = () => {
+    animationUserOverrideRef.current = true;
     setIsAnimating((prev) => !prev);
   }
 
 
   return (
     <div className="art-root">
+      <div className="sr-only" role="status" aria-live="polite">
+        {accessibilitySummary}
+      </div>
       <ArtContainer state={generationState} />
       <div className="art-label">
         datart · {generationState.styleId} · client-side generative

--- a/src/components/ui/ControlPanel.css
+++ b/src/components/ui/ControlPanel.css
@@ -71,6 +71,7 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  min-height: 32px;
 }
 
 .control-input,
@@ -89,8 +90,9 @@
 }
 
 .control-button {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.6rem;
+  min-height: 36px;
+  font-size: 0.78rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.7);
   background: rgba(30, 64, 175, 0.9);
@@ -117,6 +119,7 @@
 
 .control-range {
   flex: 1;
+  min-height: 32px;
 }
 
 .control-range-value {

--- a/src/components/ui/ControlPanel.tsx
+++ b/src/components/ui/ControlPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, type ChangeEvent } from "react";
+import React, { useEffect, useState, useRef, type ChangeEvent } from "react";
 import type { Mode, StyleId } from "../../logic/types";
 import { useIsDev } from "../../hooks/useIsDev";
 import { useClickOutside } from "../../hooks/useClickOutside";
@@ -73,6 +73,23 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
 
   const dialValue = manualSeed ?? 50; // 0–100 dial
   const complexityValue = complexity;
+  const controlsPanelId = isMobile
+    ? "datart-controls-panel-mobile"
+    : "datart-controls-panel";
+  const roundedAudioVolume = Math.round(audioVolume * 100);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open]);
 
   const handleSeedChange = (
     event: ChangeEvent<HTMLInputElement>
@@ -141,6 +158,9 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
         {/* floating toggle */}
         <button 
           className={toggleClasses} 
+          type="button"
+          aria-expanded={open}
+          aria-controls={controlsPanelId}
           onClick={() => setOpen((o) => !o)}
         >
           <span className="panel-toggle__dot" />
@@ -148,7 +168,12 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
         </button>
 
         {open && (
-        <div className="control-panel panel-body panel-floating control-panel--mobile control-panel--visible">
+        <div
+          id={controlsPanelId}
+          className="control-panel panel-body panel-floating control-panel--mobile control-panel--visible"
+          role="dialog"
+          aria-label="DatArt controls"
+        >
           <div className="control-header">
             <span className="control-title">Controls</span>
           </div>
@@ -222,15 +247,17 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
             <div className="control-row">
               <span className="control-label">Complexity</span>
               <div className="control-value control-seed-row">
-                <input
-                  type="range"
+                  <input
+                    type="range"
                   min={0}
                   max={100}
                   step={1}
-                  className="control-range"
-                  value={complexity}
-                  disabled={mode !== "manual"}
-                  onChange={(e) =>
+                    className="control-range"
+                    value={complexity}
+                    disabled={mode !== "manual"}
+                    aria-label="Complexity"
+                    aria-valuetext={`${Math.round(complexity)} percent complexity`}
+                    onChange={(e) =>
                     onComplexityChange(Number(e.target.value))
                   }
                 />
@@ -274,12 +301,13 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                   max={100}
                   step={1}
                   className="control-range"
-                  value={Math.round(audioVolume * 100)}
+                  value={roundedAudioVolume}
                   onChange={handleAudioVolumeChange}
                   aria-label="Sound volume"
+                  aria-valuetext={`${roundedAudioVolume} percent volume`}
                 />
                 <span className="control-range-value">
-                  {Math.round(audioVolume * 100)}
+                  {roundedAudioVolume}
                 </span>
               </div>
               <div className="control-hint">{audioSummary}</div>
@@ -301,6 +329,9 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
     <div ref={rootRef}>
       <button
         className={toggleClasses}
+        type="button"
+        aria-expanded={open}
+        aria-controls={controlsPanelId}
         onClick={() => setOpen((o) => !o)}
       >
         <span className="panel-toggle__dot" />
@@ -308,7 +339,13 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
       </button>
 
       {open && (
-        <div className={panelCls} style={panelStyle}>
+        <div
+          id={controlsPanelId}
+          className={panelCls}
+          style={panelStyle}
+          role="dialog"
+          aria-label="DatArt controls"
+        >
           <div className="control-body">
             <div 
               className="panel-header drag-handle"
@@ -387,6 +424,8 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                       value={dialValue}
                       onChange={handleSeedChange}
                       disabled={mode !== "manual"}
+                      aria-label="Manual seed"
+                      aria-valuetext={`${dialValue} seed value`}
                     />
                     <span className="control-range-value">
                       {dialValue}
@@ -419,6 +458,8 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                       value={complexityValue}
                       onChange={handleComplexityChange}
                       disabled={mode !== "manual" || isAnimating}
+                      aria-label="Complexity"
+                      aria-valuetext={`${Math.round(complexityValue)} percent complexity`}
                     />
                     <span className="control-range-value">
                       {Math.round(complexityValue)}
@@ -470,12 +511,13 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                       max={100}
                       step={1}
                       className="control-range"
-                      value={Math.round(audioVolume * 100)}
+                      value={roundedAudioVolume}
                       onChange={handleAudioVolumeChange}
                       aria-label="Sound volume"
+                      aria-valuetext={`${roundedAudioVolume} percent volume`}
                     />
                     <span className="control-range-value">
-                      {Math.round(audioVolume * 100)}
+                      {roundedAudioVolume}
                     </span>
                   </div>
                   <div className="control-hint">{audioSummary}</div>

--- a/src/components/ui/DebugPanel.tsx
+++ b/src/components/ui/DebugPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import type { GenerationState, Mode } from "../../logic/types";
 import { useIsDev } from "../../hooks/useIsDev";
 import { useClickOutside } from "../../hooks/useClickOutside";
@@ -66,6 +66,20 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
     (isMobile ? " debug-panel--mobile" : "");
 
   const activePanelStyle = isMobile ? undefined : panelStyle;
+  const debugPanelId = "datart-debug-panel";
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open]);
 
   // HUD closed
   if (hudHidden) return null;
@@ -74,6 +88,9 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
     <div ref={rootRef}>
       <button
         className={toggleClasses}
+        type="button"
+        aria-expanded={open}
+        aria-controls={debugPanelId}
         onClick={() => setOpen((o) => !o)}
       >
         <span className="panel-toggle__dot" />
@@ -82,8 +99,11 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
 
       {open && (
         <div 
+          id={debugPanelId}
           className={panelClasses}
           style={activePanelStyle}
+          role="dialog"
+          aria-label="Generation debug"
         >
           <div className="panel-header drag-handle" {...handleProps}>
             <h2 className="panel-title">Generation Debug</h2>

--- a/src/components/ui/MiniHud.css
+++ b/src/components/ui/MiniHud.css
@@ -32,6 +32,12 @@
   line-height: 1;
 }
 
+.mini-hud__button:focus-visible,
+.mini-hud__label:focus-visible {
+  outline: 3px solid #facc15;
+  outline-offset: 3px;
+}
+
 .mini-hud__button--arrow {
   font-size: 1.1rem;
 }

--- a/src/components/ui/MiniHud.tsx
+++ b/src/components/ui/MiniHud.tsx
@@ -64,7 +64,7 @@ const MiniHud: React.FC<MiniHudProps> = ({
       <button 
         type="button"
         className="mini-hud__button mini-hud__button--arrow"
-        aria-label="Previous style"
+        aria-label={`Previous style. Current style is ${labelText}`}
         onClick={() => handleStep(-1)}
       >
         &lt;
@@ -74,6 +74,12 @@ const MiniHud: React.FC<MiniHudProps> = ({
       <button 
         type="button"
         className="mini-hud__label"
+        aria-pressed={isAnimating}
+        aria-label={
+          isAnimating
+            ? `Stop complexity animation for ${labelText}`
+            : `Start complexity animation for ${labelText}`
+        }
         onClick={onToggleAnimation}
         title={
           isAnimating
@@ -89,7 +95,11 @@ const MiniHud: React.FC<MiniHudProps> = ({
         type="button"
         className="mini-hud__button mini-hud__button--sound"
         aria-pressed={isAudioEnabled}
-        aria-label={isAudioEnabled ? "Stop sound" : "Start sound"}
+        aria-label={
+          isAudioEnabled
+            ? `Stop sound for ${labelText}`
+            : `Start sound for ${labelText}`
+        }
         onClick={() => {
           void onToggleAudio();
         }}
@@ -102,7 +112,7 @@ const MiniHud: React.FC<MiniHudProps> = ({
       <button 
         type="button"
         className="mini-hud__button mini-hud__button--arrow"
-        aria-label="Next style"
+        aria-label={`Next style. Current style is ${labelText}`}
         onClick={() => handleStep(1)}
       >
         &gt;

--- a/src/components/ui/panel.css
+++ b/src/components/ui/panel.css
@@ -22,6 +22,13 @@
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.55);
 }
 
+.panel-toggle:focus-visible,
+.control-panel :focus-visible,
+.debug-panel :focus-visible {
+  outline: 3px solid #facc15;
+  outline-offset: 3px;
+}
+
 /* Controls vs debug positions */
 .panel-toggle--controls {
   left: 0.75rem;

--- a/src/logic/accessibilitySummary.ts
+++ b/src/logic/accessibilitySummary.ts
@@ -1,0 +1,49 @@
+import { STYLES } from "../components/art/styleRegistry";
+import type { AudioState } from "./audioMapping";
+import type { GenerationState } from "./types";
+
+interface AccessibilitySummaryOptions {
+  generationState: GenerationState;
+  audioState: AudioState;
+  isAnimating: boolean;
+  isAudioEnabled: boolean;
+  audioVolume: number;
+  prefersReducedMotion: boolean;
+}
+
+function getStyleLabel(styleId: GenerationState["styleId"]): string {
+  return STYLES[styleId]?.label ?? styleId;
+}
+
+function getPaletteSummary(palette: string[]): string {
+  if (!palette.length) return "no generated colors";
+  return `${palette.length} generated colors`;
+}
+
+export function buildAccessibilitySummary({
+  generationState,
+  audioState,
+  isAnimating,
+  isAudioEnabled,
+  audioVolume,
+  prefersReducedMotion,
+}: AccessibilitySummaryOptions): string {
+  const styleLabel = getStyleLabel(generationState.styleId);
+  const animationState = isAnimating ? "animation on" : "animation off";
+  const motionPreference = prefersReducedMotion
+    ? "reduced motion requested"
+    : "standard motion";
+  const soundState = isAudioEnabled
+    ? `sound on at ${Math.round(audioVolume * 100)} percent volume`
+    : "sound off";
+
+  return [
+    `DatArt generated ${styleLabel}.`,
+    `Mode ${generationState.seedSource === "manualDial" ? "manual seed" : "automatic"}.`,
+    `Complexity ${Math.round(generationState.complexity)}.`,
+    `${animationState}; ${motionPreference}.`,
+    `${soundState}.`,
+    `Audio profile: ${audioState.summary}.`,
+    `Palette has ${getPaletteSummary(generationState.palette)}.`,
+  ].join(" ");
+}

--- a/tests/logic/accessibilitySummary.test.ts
+++ b/tests/logic/accessibilitySummary.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildAccessibilitySummary } from "../../src/logic/accessibilitySummary";
+import { buildAudioState } from "../../src/logic/audioMapping";
+import { buildGenerationState } from "../../src/logic/generation";
+import type { GenerationOptions, UserTraits } from "../../src/logic/types";
+
+const traits: UserTraits = {
+  timeZone: "America/New_York",
+  userAgent: "Mozilla/5.0 Firefox/121.0",
+  language: "en-US",
+  screenWidth: 1440,
+  screenHeight: 900,
+  devicePixelRatio: 2,
+  darkMode: true,
+};
+
+const options: GenerationOptions = {
+  mode: "manual",
+  manualSeed: 42,
+  manualStyle: "tree",
+  complexity: 64,
+  paletteShift: 0,
+};
+
+describe("buildAccessibilitySummary", () => {
+  it("summarizes visual, motion, and sound state", () => {
+    const generationState = buildGenerationState(traits, options);
+    const audioState = buildAudioState(generationState);
+
+    const summary = buildAccessibilitySummary({
+      generationState,
+      audioState,
+      isAnimating: false,
+      isAudioEnabled: true,
+      audioVolume: 0.55,
+      prefersReducedMotion: true,
+    });
+
+    expect(summary).toContain("Recursive Tree");
+    expect(summary).toContain("Complexity 64");
+    expect(summary).toContain("animation off");
+    expect(summary).toContain("reduced motion requested");
+    expect(summary).toContain("sound on at 55 percent volume");
+    expect(summary).toContain(audioState.summary);
+  });
+});


### PR DESCRIPTION
## Summary
- Add screen-reader summary for generated art and sonification state
- Improve keyboard and ARIA behavior for MiniHud, Controls, and Debug panels
- Respect reduced-motion preference by starting animation off unless manually enabled
- Add visible focus styling and larger internal control targets
- Document manual accessibility checks

## Details
This adds a screen-reader-only live summary describing:
- current visual style
- generation mode
- complexity
- animation and reduced-motion state
- sound state and volume
- audio profile
- palette count

Controls now expose clearer semantics:
- MiniHud buttons include action-specific labels and pressed states
- Controls and Debug toggles expose `aria-expanded` and `aria-controls`
- Open panels use dialog roles
- Escape closes open panels
- sliders expose clearer value text

## Verification
- `npm run ci`
- Manual keyboard navigation check
- Manual Escape-to-close panel check
- Manual reduced-motion reload check
- Manual screen-reader summary check